### PR TITLE
Wire auxiliary_matcher match_via_auxiliary to report total

### DIFF
--- a/html/main.css
+++ b/html/main.css
@@ -1103,6 +1103,47 @@ table.quick_compare_table td {
 	line-height: 1;
 }
 
+/* ========== Job progress indicator ========== */
+
+/* Renders under the status chip when a job has published a JobProgress
+   payload in jobs.json. Two render modes:
+   - .jobs-progress-bar  for jobs with a known total (real percentage);
+   - .jobs-progress-text for counter-only (e.g. autoscrape with an
+     unsized outermost level, or strategies without a total query yet).
+*/
+.jobs-progress {
+	margin-top: 0.2rem;
+	font-size: 0.75rem;
+	line-height: 1;
+}
+
+.jobs-progress-bar {
+	display: block;
+	width: 6rem;
+	height: 0.4rem;
+	background: #e9ecef;
+	border-radius: 0.2rem;
+	overflow: hidden;
+}
+
+.jobs-progress-bar-fill {
+	display: block;
+	height: 100%;
+	background: #0d6efd;
+	transition: width 0.3s ease;
+}
+
+.jobs-progress-label {
+	display: block;
+	color: #6c757d;
+	margin-top: 0.1rem;
+}
+
+.jobs-progress-text {
+	display: block;
+	color: #6c757d;
+}
+
 /* ========== Large catalogs ========== */
 
 .mnm-lc-catalog-card {

--- a/html/vue-components/jobs.js
+++ b/html/vue-components/jobs.js
@@ -215,6 +215,48 @@ export default Vue.extend({
             this.load();
             if (typeof window != 'undefined' && window.scrollTo) window.scrollTo(0, 0);
         },
+        // Progress payload (server-parsed from jobs.json under the
+        // `progress` field). Returns null when the job hasn't published
+        // any progress (legacy rows, jobs that don't track it yet).
+        progress_of : function(job) {
+            return (job && job.progress) ? job.progress : null;
+        },
+        has_progress_bar : function(job) {
+            const p = this.progress_of(job);
+            return !!(p && p.percent != null && p.total != null && p.total > 0);
+        },
+        has_progress_counter : function(job) {
+            // Counter-only when we know `processed` but no `total`.
+            const p = this.progress_of(job);
+            return !!(p && p.processed != null && (p.total == null || p.total === 0));
+        },
+        progress_percent : function(job) {
+            const p = this.progress_of(job);
+            if (!p || p.percent == null) return 0;
+            return Math.min(100, Math.max(0, p.percent));
+        },
+        progress_label : function(job) {
+            const p = this.progress_of(job);
+            if (!p) return '';
+            if (p.total != null && p.total > 0) {
+                const pct = (p.percent != null) ? p.percent.toFixed(1) : '?';
+                return `${pct}% (${this.fmt_count(p.processed)} / ${this.fmt_count(p.total)})`;
+            }
+            return `${this.fmt_count(p.processed)} done`;
+        },
+        fmt_count : function(n) {
+            if (n == null) return '?';
+            // 12,345 — easier to read at a glance than 12345.
+            return Number(n).toLocaleString();
+        },
+        // Show the progress indicator only for jobs that are doing work
+        // right now (or queued); DONE/FAILED/DEACTIVATED would just be
+        // visual clutter — the final outcome already lives in the status
+        // chip.
+        show_progress : function(job) {
+            return ACTIVE_JOB_STATUSES.has(job.status)
+                && (this.has_progress_bar(job) || this.has_progress_counter(job));
+        },
         // Returns true if the current user may control (stop/pause/resume) this job.
         // Mirrors the server-side is_job_manager check.
         can_control_job : function(job) {
@@ -333,6 +375,13 @@ export default Vue.extend({
                             class='jobs-ctrl-btn btn btn-sm btn-outline-danger'
                             title='Stop job' @click.prevent='manage_job(job.id,"stop")'>&#x23F9;</button>
                     </span>
+                    <div v-if='show_progress(job)' class='jobs-progress' :title='progress_label(job)'>
+                        <span v-if='has_progress_bar(job)' class='jobs-progress-bar'>
+                            <span class='jobs-progress-bar-fill' :style='{ width: progress_percent(job) + "%" }'></span>
+                        </span>
+                        <span class='jobs-progress-label' v-if='has_progress_bar(job)'>{{progress_percent(job).toFixed(1)}}%</span>
+                        <span class='jobs-progress-text' v-else>{{progress_label(job)}}</span>
+                    </div>
                 </td>
                 <td class='jobs-ts'>
                     <span class='jobs-ts-date'>{{date_part(job.last_ts)}}</span>

--- a/src/automatch/strategies.rs
+++ b/src/automatch/strategies.rs
@@ -319,6 +319,22 @@ impl AutoMatch {
             .get("automatch_by_search_search_batch_size")
             .unwrap_or(&50);
 
+        // One COUNT at the start so the UI can render a real percent
+        // alongside the resume cursor. Total may drift while the job runs
+        // (entries get matched, possibly added) — accept that as cheaper
+        // than re-querying every batch. `from_counts` clamps overshoot to
+        // 100%.
+        let total = self
+            .app
+            .storage()
+            .number_of_entries_in_catalog_filtered(
+                catalog_id,
+                &MatchState::not_fully_matched(),
+            )
+            .await
+            .ok()
+            .map(|n| n as u64);
+
         loop {
             let results = self
                 .app
@@ -333,7 +349,7 @@ impl AutoMatch {
                 break;
             }
             offset += results.len();
-            let _ = self.remember_offset(offset).await;
+            let _ = self.report_progress(offset as u64, total).await;
         }
         let _ = self.clear_offset().await;
         Ok(())

--- a/src/autoscrape.rs
+++ b/src/autoscrape.rs
@@ -1,10 +1,11 @@
 use crate::app_state::AppContext;
-use crate::autoscrape_levels::AutoscrapeLevel;
+use crate::autoscrape_levels::{AutoscrapeLevel, sized_prefix_index};
 use crate::autoscrape_resolve::RE_SIMPLE_SPACE;
 use crate::autoscrape_scraper::AutoscrapeScraper;
 use crate::catalog::Catalog;
 use crate::extended_entry::ExtendedEntry;
 use crate::job::{Job, Jobbable};
+use crate::job_progress::{JobProgress, merge_progress_into_json};
 use anyhow::Result;
 use futures::StreamExt;
 use serde_json::{Value, json};
@@ -336,13 +337,29 @@ impl Autoscrape {
     }
 
     pub async fn remember_state(&mut self) -> Result<()> {
-        let json: Vec<Value> = self
+        // Persist level state under `levels` (new object shape) so the
+        // typed progress payload can sit alongside without overwriting it.
+        // `start()` keeps a backward-compatible reader for the legacy bare
+        // array shape that pre-progress autoscrape runs wrote.
+        let levels: Vec<Value> = self
             .levels
             .iter()
             .map(|level| level.level_type().get_state())
             .collect();
-        let json = json!(json);
-        self.remember_job_data(&json).await?;
+        let mut state = json!({ "levels": levels });
+
+        // Coarse percentage over the sized prefix of levels (Keys/Range);
+        // None when the outermost level is unsized (Follow/MediaWiki),
+        // in which case we still publish a `urls_loaded` counter via
+        // `processed` so the UI has something to render.
+        let (processed, total) = match sized_prefix_index(&self.levels) {
+            Some((flat, total)) => (flat, Some(total)),
+            None => (self.urls_loaded as u64, None),
+        };
+        let progress = JobProgress::from_counts(processed, total);
+        state = merge_progress_into_json(Some(&state), &progress);
+
+        self.remember_job_data(&state).await?;
         Ok(())
     }
 
@@ -426,7 +443,21 @@ impl Autoscrape {
             .autoscrape_start(autoscrape_id)
             .await?;
         if let Some(json) = self.get_last_job_data().await {
-            if let Some(arr) = json.as_array() {
+            // Accept both shapes for backward compatibility:
+            // - new: object with `levels` array (+ optional `progress`);
+            // - legacy: bare array of level states.
+            let levels_value = json
+                .as_object()
+                .and_then(|o| o.get("levels"))
+                .cloned()
+                .or_else(|| {
+                    if json.is_array() {
+                        Some(json.clone())
+                    } else {
+                        None
+                    }
+                });
+            if let Some(Value::Array(arr)) = levels_value {
                 if arr.len() == self.levels.len() {
                     arr.iter()
                         .enumerate()

--- a/src/autoscrape_levels.rs
+++ b/src/autoscrape_levels.rs
@@ -14,6 +14,17 @@ trait Level {
     fn current(&self) -> String;
     fn get_state(&self) -> Value;
     fn set_state(&mut self, json: &Value);
+
+    /// Total number of `tick()` outcomes this level will yield, if it can
+    /// be determined ahead of time. `None` for data-driven levels (Follow,
+    /// MediaWiki) whose size depends on a yet-to-be-fetched response.
+    fn size_hint(&self) -> Option<usize>;
+
+    /// Zero-based index of the current `tick()` within `size_hint()`. `None`
+    /// when `size_hint()` is `None`. Used together with `size_hint` to
+    /// compute the flat mixed-radix index into the cartesian product of
+    /// levels.
+    fn position_hint(&self) -> Option<usize>;
 }
 
 #[derive(Debug, Clone)]
@@ -49,6 +60,14 @@ impl Level for AutoscrapeKeys {
                 self.position = position as usize;
             }
         }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.keys.len())
+    }
+
+    fn position_hint(&self) -> Option<usize> {
+        Some(self.position.min(self.keys.len()))
     }
 }
 
@@ -102,6 +121,26 @@ impl Level for AutoscrapeRange {
                 self.current_value = current_value;
             }
         }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        // Range is inclusive of `end` (tick returns true only after
+        // current_value > end), so e.g. start=1,end=3,step=1 yields three
+        // values: 1, 2, 3. Defensive against zero/inverted ranges that
+        // would be configuration bugs but shouldn't panic the worker.
+        if self.step == 0 || self.start > self.end {
+            return None;
+        }
+        Some(((self.end - self.start) / self.step) as usize + 1)
+    }
+
+    fn position_hint(&self) -> Option<usize> {
+        if self.step == 0 || self.current_value < self.start {
+            return None;
+        }
+        let size = self.size_hint()?;
+        let pos = ((self.current_value - self.start) / self.step) as usize;
+        Some(pos.min(size))
     }
 }
 
@@ -161,6 +200,17 @@ impl Level for AutoscrapeFollow {
                 self.regex = regex.to_string();
             }
         }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        // Size is data-driven (depends on the response of an HTTP fetch
+        // performed on each outer-level tick), so it cannot be known up
+        // front. Treated as opaque by the percentage calculation.
+        None
+    }
+
+    fn position_hint(&self) -> Option<usize> {
+        None
     }
 }
 
@@ -272,6 +322,16 @@ impl Level for AutoscrapeMediaWiki {
             }
         }
     }
+
+    fn size_hint(&self) -> Option<usize> {
+        // Streamed via apfrom; total unknown until the last page is
+        // empty. Treated as opaque by the percentage calculation.
+        None
+    }
+
+    fn position_hint(&self) -> Option<usize> {
+        None
+    }
 }
 
 impl AutoscrapeMediaWiki {
@@ -379,6 +439,65 @@ impl AutoscrapeLevelType {
             AutoscrapeLevelType::MediaWiki(x) => x.set_state(json),
         }
     }
+
+    pub fn size_hint(&self) -> Option<usize> {
+        match self {
+            AutoscrapeLevelType::Keys(x) => x.size_hint(),
+            AutoscrapeLevelType::Range(x) => x.size_hint(),
+            AutoscrapeLevelType::Follow(x) => x.size_hint(),
+            AutoscrapeLevelType::MediaWiki(x) => x.size_hint(),
+        }
+    }
+
+    pub fn position_hint(&self) -> Option<usize> {
+        match self {
+            AutoscrapeLevelType::Keys(x) => x.position_hint(),
+            AutoscrapeLevelType::Range(x) => x.position_hint(),
+            AutoscrapeLevelType::Follow(x) => x.position_hint(),
+            AutoscrapeLevelType::MediaWiki(x) => x.position_hint(),
+        }
+    }
+}
+
+/// Returns `(flat_index, total)` over the cartesian product of the
+/// longest contiguous prefix of levels whose size is knowable up front
+/// (Keys, Range). Inner levels with unknown size (Follow, MediaWiki)
+/// terminate the prefix; their state contributes nothing.
+///
+/// Returns `None` when no level has a size hint or when the prefix's
+/// total iteration count would be zero. The percent is derived by
+/// [`crate::job_progress::JobProgress::from_counts`].
+///
+/// Math: a standard mixed-radix decode over the sized prefix —
+/// `flat = Σᵢ positionᵢ · Πⱼ₍ⱼ>ᵢ₎ sizeⱼ`, with `total = Πᵢ sizeᵢ`. This
+/// matches the autoscrape outer-to-inner cartesian iteration order
+/// (`Autoscrape::tick` resets level[N-1] when it exhausts, ticking
+/// level[N-2]).
+pub fn sized_prefix_index(levels: &[AutoscrapeLevel]) -> Option<(u64, u64)> {
+    let mut sizes: Vec<u64> = Vec::with_capacity(levels.len());
+    let mut positions: Vec<u64> = Vec::with_capacity(levels.len());
+    for level in levels {
+        match (level.size_hint(), level.position_hint()) {
+            (Some(s), Some(p)) => {
+                sizes.push(s as u64);
+                positions.push(p as u64);
+            }
+            _ => break,
+        }
+    }
+    if sizes.is_empty() {
+        return None;
+    }
+    let total: u64 = sizes.iter().product();
+    if total == 0 {
+        return None;
+    }
+    let mut flat: u64 = 0;
+    for i in 0..sizes.len() {
+        let inner_product: u64 = sizes[i + 1..].iter().product();
+        flat += positions[i] * inner_product;
+    }
+    Some((flat, total))
 }
 
 #[derive(Debug, Clone)]
@@ -422,6 +541,18 @@ impl AutoscrapeLevel {
     pub fn current(&self) -> String {
         self.level_type.current()
     }
+
+    /// Total number of `tick()` outcomes this level will yield, or `None`
+    /// if the level's size is data-driven (Follow, MediaWiki).
+    pub fn size_hint(&self) -> Option<usize> {
+        self.level_type.size_hint()
+    }
+
+    /// Zero-based index of the current `tick()` within `size_hint()`, or
+    /// `None` if the level is unsized.
+    pub fn position_hint(&self) -> Option<usize> {
+        self.level_type.position_hint()
+    }
 }
 
 #[cfg(test)]
@@ -460,5 +591,154 @@ mod tests {
         assert_eq!(level.current(), "3");
         assert!(level.tick().await);
         assert_eq!(level.current(), "4");
+    }
+
+    // size_hint / position_hint ─────────────────────────────────────────
+
+    #[test]
+    fn keys_size_and_position_hints() {
+        let json = json!({"mode": "keys", "keys": ["a", "b", "c"]});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.size_hint(), Some(3));
+        assert_eq!(level.position_hint(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn keys_position_hint_advances_with_tick() {
+        let json = json!({"mode": "keys", "keys": ["a", "b", "c"]});
+        let mut level = AutoscrapeLevel::from_json(&json).unwrap();
+        level.tick().await;
+        assert_eq!(level.position_hint(), Some(1));
+        level.tick().await;
+        assert_eq!(level.position_hint(), Some(2));
+    }
+
+    #[test]
+    fn range_size_hint_inclusive_of_end() {
+        // start=1, end=3, step=1 yields 3 values: 1, 2, 3.
+        let json = json!({"mode": "range", "start": 1, "end": 3, "step": 1});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.size_hint(), Some(3));
+    }
+
+    #[test]
+    fn range_size_hint_with_step() {
+        // start=0, end=6, step=2 yields 4 values: 0, 2, 4, 6.
+        let json = json!({"mode": "range", "start": 0, "end": 6, "step": 2});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.size_hint(), Some(4));
+    }
+
+    #[test]
+    fn range_position_hint_zero_at_start() {
+        let json = json!({"mode": "range", "start": 2000, "end": 2025, "step": 1});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.position_hint(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn range_position_hint_advances() {
+        let json = json!({"mode": "range", "start": 2000, "end": 2005, "step": 1});
+        let mut level = AutoscrapeLevel::from_json(&json).unwrap();
+        level.tick().await; // 2001
+        level.tick().await; // 2002
+        assert_eq!(level.position_hint(), Some(2));
+    }
+
+    #[test]
+    fn range_size_hint_none_on_zero_step() {
+        // Defensive: step=0 would be a configuration bug; don't crash.
+        let json = json!({"mode": "range", "start": 0, "end": 5, "step": 0});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.size_hint(), None);
+    }
+
+    #[test]
+    fn follow_returns_none_for_both_hints() {
+        // Follow is data-driven; size/position cannot be known ahead.
+        let json = json!({"mode": "follow", "url": "http://example.com/$1", "rx": "(.+)"});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.size_hint(), None);
+        assert_eq!(level.position_hint(), None);
+    }
+
+    #[test]
+    fn mediawiki_returns_none_for_both_hints() {
+        let json = json!({"mode": "mediawiki", "url": "https://en.wikipedia.org/w/api.php"});
+        let level = AutoscrapeLevel::from_json(&json).unwrap();
+        assert_eq!(level.size_hint(), None);
+        assert_eq!(level.position_hint(), None);
+    }
+
+    // sized_prefix_percent ──────────────────────────────────────────────
+
+    fn keys_level(n: usize) -> AutoscrapeLevel {
+        let keys: Vec<Value> = (0..n).map(|i| json!(format!("k{i}"))).collect();
+        AutoscrapeLevel::from_json(&json!({"mode": "keys", "keys": keys})).unwrap()
+    }
+
+    fn range_level(start: u64, end: u64, step: u64) -> AutoscrapeLevel {
+        AutoscrapeLevel::from_json(&json!({
+            "mode": "range", "start": start, "end": end, "step": step,
+        }))
+        .unwrap()
+    }
+
+    fn follow_level() -> AutoscrapeLevel {
+        AutoscrapeLevel::from_json(&json!({
+            "mode": "follow", "url": "http://example.com/", "rx": "(.+)",
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn prefix_index_empty_levels_is_none() {
+        assert_eq!(sized_prefix_index(&[]), None);
+    }
+
+    #[test]
+    fn prefix_index_outermost_unsized_is_none() {
+        let levels = vec![follow_level(), keys_level(10)];
+        assert_eq!(sized_prefix_index(&levels), None);
+    }
+
+    #[test]
+    fn prefix_index_at_start_is_zero_flat() {
+        // Two levels of size 10 × 20 = 200 total iterations, all at position 0.
+        let levels = vec![keys_level(10), range_level(0, 19, 1)];
+        assert_eq!(sized_prefix_index(&levels), Some((0, 200)));
+    }
+
+    #[tokio::test]
+    async fn prefix_index_mid_iteration() {
+        // outer keys=10, inner range=20 (start 0, end 19, step 1)
+        // Tick outer 3 times, inner 7 times → positions = (3, 7).
+        // flat = 3*20 + 7 = 67, total = 200.
+        let mut levels = vec![keys_level(10), range_level(0, 19, 1)];
+        for _ in 0..3 {
+            levels[0].tick().await;
+        }
+        for _ in 0..7 {
+            levels[1].tick().await;
+        }
+        assert_eq!(sized_prefix_index(&levels), Some((67, 200)));
+    }
+
+    #[tokio::test]
+    async fn prefix_index_coarse_when_inner_unsized() {
+        // Outer keys=10 (sized), inner follow (unsized). After ticking
+        // outer 3 times, prefix is just keys: flat=3, total=10.
+        let mut levels = vec![keys_level(10), follow_level()];
+        for _ in 0..3 {
+            levels[0].tick().await;
+        }
+        assert_eq!(sized_prefix_index(&levels), Some((3, 10)));
+    }
+
+    #[test]
+    fn prefix_index_zero_total_is_none() {
+        // A 0-key list yields total=0; avoid div by zero.
+        let levels = vec![keys_level(0)];
+        assert_eq!(sized_prefix_index(&levels), None);
     }
 }

--- a/src/auxiliary_matcher/finder.rs
+++ b/src/auxiliary_matcher/finder.rs
@@ -45,6 +45,19 @@ impl AuxiliaryMatcher {
         let sparql_batch_size = self.get_sparql_batch_size();
         let search_batch_size = self.get_search_batch_size();
         let mw_api = self.app.wikidata().get_mw_api().await?;
+        // COUNT matching the same WHERE clause the paged fetch uses. One
+        // query at job start; small overhead vs hours-long body of work.
+        let total = self
+            .app
+            .storage()
+            .auxiliary_matcher_match_via_aux_count(
+                catalog_id,
+                &extid_props,
+                &blacklisted_catalogs,
+            )
+            .await
+            .ok()
+            .map(|n| n as u64);
         loop {
             let results = self
                 .app
@@ -74,7 +87,7 @@ impl AuxiliaryMatcher {
                 break;
             }
             offset += results.len();
-            let _ = self.remember_offset(offset).await;
+            let _ = self.report_progress(offset as u64, total).await;
         }
         let _ = self.clear_offset().await;
         let _ = Job::queue_simple_job(self.app.as_ref(), catalog_id, "aux2wd", None).await;

--- a/src/job.rs
+++ b/src/job.rs
@@ -14,13 +14,13 @@ use crate::php_wrapper::PhpWrapper;
 use crate::task_size::TaskSize;
 use crate::taxon_matcher::TaxonMatcher;
 use crate::update_catalog::UpdateCatalog;
+use crate::job_progress::{JobProgress, merge_progress_into_json};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use chrono::Duration;
 use chrono::Local;
 use futures::future::BoxFuture;
 use log::info;
-use serde_json::json;
 use wikimisc::timestamp::TimeStamp;
 
 /// A trait that allows to manage temporary job data (eg offset)
@@ -59,13 +59,29 @@ pub trait Jobbable {
         })
     }
 
+    /// Persist a resume cursor as `offset` in `jobs.json`. Equivalent to
+    /// [`report_progress`] with no total — emits a typed progress payload
+    /// (`{processed: offset, total: None, percent: None}`) so the UI can
+    /// still render a counter even when the strategy doesn't know its
+    /// total. Preserves any other keys in `jobs.json` (e.g. autoscrape's
+    /// `levels` array).
     async fn remember_offset(&mut self, offset: usize) -> Result<()> {
+        self.report_progress(offset as u64, None).await
+    }
+
+    /// Persist a typed progress payload to `jobs.json`, merging with the
+    /// existing document. The `offset` key is kept in sync with `processed`
+    /// for backward compatibility with [`get_last_job_offset`] and any
+    /// external readers that already parse it directly.
+    async fn report_progress(&mut self, processed: u64, total: Option<u64>) -> Result<()> {
         let job = match self.get_current_job_mut() {
             Some(job) => job,
             None => return Ok(()),
         };
-        // println!("{}: {offset} [{}]",job.get_id().await.unwrap_or(0), Utc::now());
-        job.set_json(Some(json!({ "offset": offset }))).await?;
+        let progress = JobProgress::from_counts(processed, total);
+        let existing = job.get_json_value().await;
+        let merged = merge_progress_into_json(existing.as_ref(), &progress);
+        job.set_json(Some(merged)).await?;
         Ok(())
     }
 

--- a/src/job_progress.rs
+++ b/src/job_progress.rs
@@ -1,0 +1,206 @@
+//! Typed progress payload stored under the `"progress"` key in `jobs.json`.
+//!
+//! Schema written to disk:
+//! ```json
+//! {
+//!   "offset":    1234,         // legacy resume cursor; kept in sync with `processed`
+//!   "progress": { "processed": 1234, "total": 5000, "percent": 24.68 },
+//!   "levels":   [ ... ]        // autoscrape only; opaque to the merge layer
+//! }
+//! ```
+//!
+//! Backward compatibility — readers MUST tolerate:
+//! - the old bare `{"offset": N}` shape (pre-progress jobs);
+//! - the old bare `[...]` array shape (pre-progress autoscrape).
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+/// Typed progress payload. All three fields are independently optional so
+/// callers can publish just a counter (`processed` only) when the total
+/// isn't known, or a full percentage when it is.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct JobProgress {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub percent: Option<f32>,
+}
+
+impl JobProgress {
+    /// Build a progress payload from raw counts. Derives `percent` only
+    /// when `total` is `Some` and non-zero; clamps to `[0.0, 100.0]` so a
+    /// `processed > total` race doesn't surface as "117 %" in the UI.
+    pub fn from_counts(processed: u64, total: Option<u64>) -> Self {
+        let percent = total.and_then(|t| {
+            if t == 0 {
+                None
+            } else {
+                let raw = (processed as f64 / t as f64) * 100.0;
+                Some(raw.clamp(0.0, 100.0) as f32)
+            }
+        });
+        Self {
+            processed: Some(processed),
+            total,
+            percent,
+        }
+    }
+
+    /// Parse a `progress` sub-object out of a `jobs.json` document. Returns
+    /// `None` for legacy shapes (bare offset object, bare autoscrape array)
+    /// where there is no progress payload to surface.
+    pub fn from_json(json: &Value) -> Option<Self> {
+        json.as_object()?
+            .get("progress")
+            .and_then(|p| serde_json::from_value(p.clone()).ok())
+    }
+}
+
+/// Merge a `progress` payload (and a mirrored `offset` cursor) into the
+/// existing `jobs.json` document, preserving any other keys that already
+/// live there (e.g. autoscrape's `levels` array).
+///
+/// Legacy shapes are normalised to the new object form:
+/// - `null` / `None` → new object.
+/// - bare `{"offset": N}` → object retains `offset`, gains `progress`.
+/// - bare `[...]` (autoscrape's old level array) → wrapped as `{"levels": [...], ...}`.
+///
+/// The mirrored `offset` is kept so `Jobbable::get_last_job_offset()` (and
+/// any external readers that already parse `json.offset`) continue to work
+/// unchanged.
+pub fn merge_progress_into_json(existing: Option<&Value>, progress: &JobProgress) -> Value {
+    let mut obj = match existing {
+        Some(Value::Object(map)) => map.clone(),
+        Some(Value::Array(arr)) => {
+            // Legacy autoscrape shape: wrap the level array under "levels"
+            // so future writes are in the new object form.
+            let mut m = Map::new();
+            m.insert("levels".to_string(), Value::Array(arr.clone()));
+            m
+        }
+        _ => Map::new(),
+    };
+
+    // Mirror `processed` into `offset` so resume-on-restart keeps working
+    // for callers that read `json.offset` directly.
+    if let Some(p) = progress.processed {
+        obj.insert("offset".to_string(), json!(p));
+    }
+    obj.insert(
+        "progress".to_string(),
+        serde_json::to_value(progress).unwrap_or(Value::Null),
+    );
+    Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_counts_derives_percent_when_total_known() {
+        let p = JobProgress::from_counts(25, Some(100));
+        assert_eq!(p.processed, Some(25));
+        assert_eq!(p.total, Some(100));
+        assert_eq!(p.percent, Some(25.0));
+    }
+
+    #[test]
+    fn from_counts_omits_percent_when_total_unknown() {
+        let p = JobProgress::from_counts(42, None);
+        assert_eq!(p.processed, Some(42));
+        assert_eq!(p.total, None);
+        assert_eq!(p.percent, None);
+    }
+
+    #[test]
+    fn from_counts_omits_percent_when_total_zero() {
+        // total=0 would divide-by-zero; report processed but no percent.
+        let p = JobProgress::from_counts(0, Some(0));
+        assert_eq!(p.percent, None);
+    }
+
+    #[test]
+    fn from_counts_clamps_overflow_to_100_percent() {
+        // Defensive: if a strategy somehow reports processed > total
+        // (e.g. retry-after-skip races), we cap the bar at 100% rather
+        // than render "117 %".
+        let p = JobProgress::from_counts(117, Some(100));
+        assert_eq!(p.percent, Some(100.0));
+    }
+
+    #[test]
+    fn merge_into_empty_creates_object_with_offset_and_progress() {
+        let progress = JobProgress::from_counts(50, Some(200));
+        let merged = merge_progress_into_json(None, &progress);
+        let obj = merged.as_object().expect("object");
+        assert_eq!(obj.get("offset"), Some(&json!(50)));
+        let prog = obj.get("progress").expect("progress").as_object().unwrap();
+        assert_eq!(prog.get("processed"), Some(&json!(50)));
+        assert_eq!(prog.get("total"), Some(&json!(200)));
+        assert!(prog.get("percent").is_some());
+    }
+
+    #[test]
+    fn merge_preserves_other_keys() {
+        // Critical: autoscrape's "levels" key must survive a progress merge.
+        let existing = json!({
+            "levels": [{"position": 3}, {"current_value": 2024}],
+            "some_other_key": "keep me"
+        });
+        let progress = JobProgress::from_counts(10, Some(40));
+        let merged = merge_progress_into_json(Some(&existing), &progress);
+        let obj = merged.as_object().unwrap();
+        assert_eq!(obj.get("some_other_key"), Some(&json!("keep me")));
+        assert_eq!(
+            obj.get("levels"),
+            Some(&json!([{"position": 3}, {"current_value": 2024}]))
+        );
+        assert!(obj.get("progress").is_some());
+    }
+
+    #[test]
+    fn merge_wraps_legacy_autoscrape_array_under_levels_key() {
+        // Old autoscrape shape: bare array of level states.
+        let legacy = json!([{"position": 0}, {"current_value": 2000}]);
+        let progress = JobProgress::from_counts(0, None);
+        let merged = merge_progress_into_json(Some(&legacy), &progress);
+        let obj = merged.as_object().expect("must become object");
+        assert_eq!(
+            obj.get("levels"),
+            Some(&json!([{"position": 0}, {"current_value": 2000}]))
+        );
+    }
+
+    #[test]
+    fn merge_overwrites_offset_with_new_value() {
+        // Existing offset=10 must be replaced by the new processed=42.
+        let existing = json!({"offset": 10});
+        let progress = JobProgress::from_counts(42, None);
+        let merged = merge_progress_into_json(Some(&existing), &progress);
+        assert_eq!(merged.get("offset"), Some(&json!(42)));
+    }
+
+    #[test]
+    fn from_json_returns_none_for_legacy_offset_only() {
+        let legacy = json!({"offset": 12345});
+        assert_eq!(JobProgress::from_json(&legacy), None);
+    }
+
+    #[test]
+    fn from_json_returns_none_for_legacy_autoscrape_array() {
+        let legacy = json!([{"position": 0}]);
+        assert_eq!(JobProgress::from_json(&legacy), None);
+    }
+
+    #[test]
+    fn from_json_roundtrip() {
+        let original = JobProgress::from_counts(123, Some(456));
+        let merged = merge_progress_into_json(None, &original);
+        let parsed = JobProgress::from_json(&merged).expect("parses back");
+        assert_eq!(parsed, original);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub mod import_catalog;
 pub mod issue;
 pub mod item_creator;
 pub mod job;
+pub mod job_progress;
 pub mod job_row;
 pub mod job_runner;
 pub mod job_status;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -644,6 +644,14 @@ pub trait Storage:
 
     async fn create_catalog(&self, catalog: &Catalog) -> Result<usize>;
     async fn number_of_entries_in_catalog(&self, catalog_id: usize) -> Result<usize>;
+    /// Count entries in a catalog, filtered by a [`MatchState`] (e.g.
+    /// [`MatchState::not_fully_matched`]). Used by long-running match
+    /// strategies to report total work for progress percentage.
+    async fn number_of_entries_in_catalog_filtered(
+        &self,
+        catalog_id: usize,
+        match_state: &MatchState,
+    ) -> Result<usize>;
     async fn get_catalog_from_id(&self, catalog_id: usize) -> Result<Catalog>;
     async fn get_catalog_from_name(&self, name: &str) -> Result<Catalog>;
     async fn get_catalog_key_value_pairs(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -554,6 +554,17 @@ pub trait AuxiliaryMatcherQueries: std::fmt::Debug + Send + Sync {
         extid_props: &[String],
         blacklisted_catalogs: &[String],
     ) -> Result<Vec<AuxiliaryResults>>;
+    /// Total rows the paged [`auxiliary_matcher_match_via_aux`] would
+    /// yield over its full iteration — same WHERE clause, COUNT(*) instead
+    /// of SELECT, no LIMIT/OFFSET. Used by the `auxiliary_matcher` job to
+    /// publish a progress percentage. Returns 0 on an empty/blacklisted
+    /// configuration (does not error).
+    async fn auxiliary_matcher_match_via_aux_count(
+        &self,
+        catalog_id: usize,
+        extid_props: &[String],
+        blacklisted_catalogs: &[String],
+    ) -> Result<usize>;
     async fn auxiliary_matcher_add_auxiliary_to_wikidata(
         &self,
         blacklisted_properties: &[String],

--- a/src/storage_mysql.rs
+++ b/src/storage_mysql.rs
@@ -6059,6 +6059,37 @@ impl crate::storage::AuxiliaryMatcherQueries for StorageMySQL {
         Ok(results)
     }
 
+    async fn auxiliary_matcher_match_via_aux_count(
+        &self,
+        catalog_id: usize,
+        extid_props: &[String],
+        blacklisted_catalogs: &[String],
+    ) -> Result<usize> {
+        // Bail before constructing an invalid SQL fragment when callers
+        // pass an empty list (the paged variant would also fail here, but
+        // we're explicit so that the COUNT path can never error a job
+        // that would otherwise just no-op out of the loop).
+        if extid_props.is_empty() || blacklisted_catalogs.is_empty() {
+            return Ok(0);
+        }
+        let sql = format!(
+            "SELECT count(*) AS cnt FROM entry,auxiliary
+            WHERE entry_id=entry.id AND catalog=:catalog_id
+            {}
+            AND in_wikidata=0
+            AND aux_p IN ({})
+            AND catalog NOT IN ({})",
+            MatchState::not_fully_matched().get_sql(),
+            extid_props.join(","),
+            blacklisted_catalogs.join(",")
+        );
+        let results: Vec<usize> = sql
+            .with(params! {catalog_id})
+            .map(self.get_conn_ro().await?, |num| num)
+            .await?;
+        Ok(*results.first().unwrap_or(&0))
+    }
+
     async fn auxiliary_matcher_add_auxiliary_to_wikidata(
         &self,
         blacklisted_properties: &[String],

--- a/src/storage_mysql.rs
+++ b/src/storage_mysql.rs
@@ -505,6 +505,26 @@ impl Storage for StorageMySQL {
         Ok(*results.first().unwrap_or(&0))
     }
 
+    async fn number_of_entries_in_catalog_filtered(
+        &self,
+        catalog_id: usize,
+        match_state: &MatchState,
+    ) -> Result<usize> {
+        // `MatchState::get_sql()` returns a clause beginning with " AND ..."
+        // (or empty for "any state") so it composes safely after a fixed
+        // `WHERE catalog=:catalog_id` predicate. The MatchState values are
+        // fixed strings — no user input flows in here.
+        let sql = format!(
+            "SELECT count(*) AS cnt FROM `entry` WHERE `catalog`=:catalog_id {}",
+            match_state.get_sql()
+        );
+        let results: Vec<usize> = sql
+            .with(params! {catalog_id})
+            .map(self.get_conn_ro().await?, |num| num)
+            .await?;
+        Ok(*results.first().unwrap_or(&0))
+    }
+
     async fn get_catalog_from_id(&self, catalog_id: usize) -> Result<Catalog> {
         let sql = r"SELECT id,`name`,url,`desc`,`type`,wd_prop,wd_qual,search_wp,active,owner,note,source_item,has_person_date,taxon_run FROM `catalog` WHERE `id`=:catalog_id";
         let mut conn = self.get_conn_ro().await?;
@@ -3008,12 +3028,25 @@ impl Storage for StorageMySQL {
                     row.get::<Option<String>, _>("catalog_name").flatten();
                 let note: Option<String> = row.get::<Option<String>, _>("note").flatten();
                 let json_str: Option<String> = row.get::<Option<String>, _>("json").flatten();
+                // Surface the typed `progress` payload as a top-level
+                // field so the frontend doesn't need to parse the raw
+                // jobs.json blob. `None` for legacy shapes (bare offset
+                // object, bare autoscrape level array) and for jobs that
+                // never published progress.
+                let progress: Option<serde_json::Value> = json_str
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                    .and_then(|v| {
+                        crate::job_progress::JobProgress::from_json(&v)
+                            .and_then(|p| serde_json::to_value(p).ok())
+                    });
                 json!({
                     "id": id, "catalog": catalog, "catalog_name": catalog_name,
                     "action": action, "status": status,
                     "last_ts": last_ts, "next_ts": next_ts,
                     "repeat_after_sec": repeat_after_sec, "depends_on": depends_on,
-                    "user_id": user_id, "user_name": user_name, "note": note, "json": json_str
+                    "user_id": user_id, "user_name": user_name, "note": note,
+                    "json": json_str, "progress": progress
                 })
             })
             .await?;


### PR DESCRIPTION
## Summary
- Adds `auxiliary_matcher_match_via_aux_count` to the `AuxiliaryMatcherQueries` trait — same WHERE clause as the paged query, `COUNT(*)` instead of `SELECT`
- `match_via_auxiliary` calls it once at job start so the progress payload publishes a real percentage instead of an offset counter
- Defensive: empty `extid_props` or `blacklisted_catalogs` short-circuit to 0 rather than building invalid `IN ()` SQL

## Test plan
- [x] `cargo build --lib` clean
- [x] `cargo test --lib` 1376 passed
- [ ] After deploy, run an `auxiliary_matcher` job on a catalog with unmatched entries and watch the bar advance